### PR TITLE
Fix: Add Namespace and Dependency Updates to Resolve Build and Runtime Errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.vocsy.epub_viewer'
     compileSdkVersion 33
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.8'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.7'
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation 'com.github.kittinunf.fuel:fuel-android:2.3.1'
+    implementation 'com.github.kittinunf.fuel:fuel:2.3.1'
 }
 
 

--- a/lib/utils/util.dart
+++ b/lib/utils/util.dart
@@ -4,7 +4,7 @@ class Util {
   /// Get HEX code from [Colors], [MaterialColor],
   /// [Color] and [MaterialAccentColor]
   static String getHexFromColor(Color color) {
-    return '#${color.toString().replaceAll('ColorSwatch(', '').replaceAll('Color(0xff', '').replaceAll('MaterialColor(', '').replaceAll('MaterialAccentColor(', '').replaceAll('primary value: Color(0xff', '').replaceAll('primary', '').replaceAll('value:', '').replaceAll(')', '').trim()}';
+    return '#${color.value.toRadixString(16).padLeft(8, '0').substring(2)}';
   }
 
   /// Convert [EpubScrollDirection] to FolioReader reader String
@@ -28,6 +28,7 @@ class Util {
     String dir = (await getTemporaryDirectory()).path;
     String path = '$dir/${basename(asset)}';
     final buffer = data.buffer;
-    return File(path).writeAsBytes(buffer.asUint8List(data.offsetInBytes, data.lengthInBytes));
+    return File(path).writeAsBytes(
+        buffer.asUint8List(data.offsetInBytes, data.lengthInBytes));
   }
 }


### PR DESCRIPTION
- Namespace Addition: Introduced namespace `com.vocsy.epub_viewer` in the `android` block of the `build.gradle` file to address the error: 

    > Namespace not specified


- Dependency Updates:

    Added `implementation 'com.github.kittinunf.fuel:fuel-android:2.3.1'`
    Added `implementation 'com.github.kittinunf.fuel:fuel:2.3.1'` 

    These dependencies resolve the issue of the fuel-android dependency not being found.

- Hex Color Conversion Fix: Updated the `getHexFromColor(Color color)` method to address a runtime error where `PlatformException` occurred due to the incorrect parsing of `Color` objects. The previous method was causing a `NumberFormatException` during the parsing process in the `vocsy_epub_viewer` package for release builds on android:

    > java.lang.NumberFormatException: For input string: "Instance of 'Color'"

    The new method converts the Color object to a valid hex string format, preventing the error.
